### PR TITLE
Adding test script to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ In the react web app root folder add a proxy entry to ```package.json```. See
 ```json
 "scripts": {
     "start": "react-scripts start",
+    "test": "react-scripts test",
     "build": "react-scripts build",
     "eject": "react-scripts eject"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "test": "react-scripts test"
   },
   "proxy": "http://127.0.0.1:7071",
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -4,22 +4,22 @@
   "private": true,
   "dependencies": {
     "@azure/storage-blob": "^12.2.0-preview.1",
-    "@types/jest": "^24.0.0",
-    "@types/node": "^12.0.0",
-    "@types/react": "^16.9.0",
-    "@types/react-dom": "^16.9.0",
+    "@types/jest": "^24.9.1",
+    "@types/node": "^12.12.68",
+    "@types/react": "^16.9.53",
+    "@types/react-dom": "^16.9.8",
     "@types/react-router-dom": "^5.1.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.3",
-    "typescript": "~3.7.2"
+    "typescript": "^3.7.5"
   },
   "scripts": {
     "start": "react-scripts start",
     "test": "react-scripts test",
     "build": "react-scripts build",
-    "eject": "react-scripts eject"    
+    "eject": "react-scripts eject"
   },
   "proxy": "http://127.0.0.1:7071",
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "test": "react-scripts test",
     "build": "react-scripts build",
-    "eject": "react-scripts eject",
-    "test": "react-scripts test"
+    "eject": "react-scripts eject"    
   },
   "proxy": "http://127.0.0.1:7071",
   "eslintConfig": {
@@ -36,5 +36,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^11.1.0"
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,20 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders link to Home page', () => {
   const { getByText } = render(<App />);
-  const linkElement = getByText(/Hello/i);
-  expect(linkElement).toBeInTheDocument();
+  const homeLink = getByText('Home');
+  expect(homeLink).toBeInTheDocument();
+});
+
+test('renders link to About page', () => {
+  const { getByText } = render(<App />);
+  const aboutLink = getByText('About');
+  expect(aboutLink).toBeInTheDocument();
+});
+
+test('renders link to Viewer page', () => {
+  const { getByText } = render(<App />);
+  const viewerLink = getByText('Viewer');
+  expect(viewerLink).toBeInTheDocument();
 });

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -155,7 +155,7 @@ function Home() {
       </p>
       <hr></hr>
 
-      <video controls muted id="video" autoPlay></video>
+      <video controls id="video" autoPlay></video>
       <br></br>
 
       <p>


### PR DESCRIPTION
**What has been achieved?**

1. Adding yarn test script to package.json to allow tests to be run
2. Removing failing generic example test from App.test.tsx and adding tests specific to this app so they will succeed
3. Removing video muted option in Home.tsx (for now) to stop the error message this causes when tests are run (see: https://github.com/testing-library/react-testing-library/issues/470)
4. Updating typescript version to fix error message on yarn build: https://github.com/facebook/create-react-app/issues/8714